### PR TITLE
PHP 7.2 ImageMagick installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS && \
     rm -r /tmp/*
 
 # Install Imagemagick
-RUN apk add --no-cache imagemagick-dev libtool autoconf gcc g++ make \
-    && pecl install imagick-3.4.3 \
-    && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini \
+RUN apk add --no-cache imagemagick-dev imagemagick libtool autoconf gcc g++ make  \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
     && apk del libtool autoconf gcc g++ make
 
 # download composer in the latest stable release


### PR DESCRIPTION
Current ImageMagick version isn't working. Package is enabled in php.ini but the command `convert --version` inside the PHP container shows it's not installed properly. 
The reason might be the changed dependencies in the installed package imagemagick-dev for PHP 7.2.

Adds ImageMagick packackge installation and initialisation for PHP 7.2.